### PR TITLE
chore: bump version to 1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajirita2002/honeycomb-mcp-server",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "MCP server for interacting with honeycomb API",
   "license": "MIT",
   "author": "kajirita2002",


### PR DESCRIPTION
## Changes Made

- Bumped package version from 1.0.2 to 1.0.3 for the next release
- This version includes the removal of unused Honeycomb tools from PR #3

## Reason for Changes

Version update for a new release with reduced tool set.

## Impact Scope

- Only affects the package.json version number
- No functional changes included in this PR

## Testing Details/Plans

No testing required for version bump.