### PR TITLE
docs: update README with current available tools

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -63,141 +63,113 @@ npm start
 
 この MCP サーバーは以下のツールを提供します：
 
-#### 認証
+### 認証
 
 1. `honeycomb_auth`
-   - Honeycomb API で認証を行います
-   - 入力:
-     - `apiKey` (string, optional): Honeycomb API キー（提供されない場合、環境変数を使用）
+   - Honeycomb API で認証を行い、APIキーを検証します
+   - 入力パラメータは必要ありません（環境変数を使用）
 
-#### データセット管理
+### データセット管理
 
 1. `honeycomb_datasets_list`
-
-   - 利用可能なすべてのデータセットをリスト表示します
+   - Honeycomb環境内の利用可能なすべてのデータセットをリスト表示します
    - 入力パラメータは必要ありません
 
 2. `honeycomb_dataset_get`
-
-   - 特定のデータセットに関する情報を取得します
+   - 特定のデータセットに関する詳細情報を取得します
    - 入力:
-     - `datasetSlug` (string, required): データセットのスラグ
+     - `datasetSlug` (string, required): 取得するデータセットのスラグ
 
-3. `honeycomb_datasets_create`
-
-   - 新しいデータセットを作成します
-   - 入力:
-     - `name` (string, required): データセットの名前
-     - `description` (string, optional): データセットの説明
-
-
-
-#### カラム管理
+### カラム管理
 
 1. `honeycomb_columns_list`
-   - データセット内のすべてのカラムをリスト表示します
+   - データセット内のすべてのカラムをオプションのフィルタリングでリスト表示します
    - 入力:
      - `datasetSlug` (string, required): データセットのスラグ
+     - `key_name` (string, optional): 特定のカラム名でフィルタリング
 
-#### クエリ管理
+### クエリ管理
 
 1. `honeycomb_query_create`
-
    - データセットに対する新しいクエリを作成します
    - 入力:
      - `datasetSlug` (string, required): データセットのスラグ
-     - `query` (object, required): クエリ設定
+     - `query` (object, required): 計算、時間範囲、フィルターを含むクエリ設定オブジェクト
 
-2. `honeycomb_query_result_create`
-   - クエリを実行し、結果を返します
+2. `honeycomb_query_get`
+   - 特定のクエリに関する情報を取得します
    - 入力:
      - `datasetSlug` (string, required): データセットのスラグ
-     - `query` (object, required): クエリ設定
+     - `queryId` (string, required): 取得するクエリのID
 
-#### イベント管理
-
-1. `honeycomb_event_create`
-
-   - データセットに新しいイベントを作成します
+3. `honeycomb_query_result_create`
+   - クエリを実行し、結果を返します（クエリの実行）
    - 入力:
      - `datasetSlug` (string, required): データセットのスラグ
-     - `data` (object, required): イベントデータ
+     - `queryId` (string, required): 実行するクエリのID
+     - `disable_series` (boolean, optional): シリーズデータを無効にするかどうか
+     - `disable_total_by_aggregate` (boolean, optional): 合計集計を無効にするかどうか
+     - `disable_other_by_aggregate` (boolean, optional): その他の集計を無効にするかどうか
+     - `limit` (integer, optional): 結果の数の制限
 
+4. `honeycomb_query_result_get`
+   - 以前に実行されたクエリの結果を取得します
+   - 入力:
+     - `datasetSlug` (string, required): データセットのスラグ
+     - `queryResultId` (string, required): 取得するクエリ結果のID
 
+### データセット定義
 
-#### ボード管理
+1. `honeycomb_dataset_definitions_list`
+   - ページネーション対応のデータセット定義リストを取得します
+   - 入力:
+     - `page` (number, optional): ページ番号（1から開始）
+     - `limit` (number, optional): 1ページあたりの結果数（デフォルト: 100, 最大: 1000）
+     - `sort_by` (string, optional): ソートするフィールド（例: 'name', 'description'）
+     - `sort_order` (string, optional): ソート順序（'asc'または'desc'）
+
+### ボード管理
 
 1. `honeycomb_boards_list`
-
-   - すべてのボードをリスト表示します
+   - 利用可能なすべてのボードをリスト表示します
    - 入力パラメータは必要ありません
 
 2. `honeycomb_board_get`
-
-   - 特定のボードに関する情報を取得します
+   - 特定のボードに関する詳細情報を取得します
    - 入力:
-     - `boardId` (string, required): ボードの ID
-
-3. `honeycomb_board_create`
-
-   - 新しいボードを作成します
-   - 入力:
-     - `name` (string, required): ボードの名前
-     - `description` (string, optional): ボードの説明
-     - `query_ids` (array of strings, optional): ボードに含めるクエリのID配列
-
-4. `honeycomb_board_update`
-
-   - 既存のボードを更新します
-   - 入力:
-     - `boardId` (string, required): 更新するボードの ID
-     - `name` (string, optional): ボードの新しい名前
-     - `description` (string, optional): ボードの新しい説明
-     - `query_ids` (array of strings, optional): ボードに含める新しいクエリのID配列
-
-
-
-#### マーカー管理
-
-1. `honeycomb_markers_list`
-
-   - データセットのすべてのマーカーをリスト表示します
-   - 入力:
-     - `datasetSlug` (string, required): データセットのスラグ
-
-2. `honeycomb_marker_create`
-
-   - 新しいマーカーを作成します
-   - 入力:
-     - `datasetSlug` (string, required): データセットのスラグ
-     - `message` (string, required): マーカーのメッセージ
-     - `type` (string, required): マーカーのタイプ
-     - `start_time` (string, required): マーカーの開始時間
-     - `end_time` (string, optional): マーカーの終了時間
-     - `url` (string, optional): マーカーに関連付けられた URL
-
-
-
+     - `boardId` (string, required): 取得するボードのID
 
 
 ## 使用例
 
-以下は、Claude AI がこの MCP サーバーを使用して新しい Honeycomb データセットを作成し、イベントを追加する例です：
+以下は、Claude AIがこのMCPサーバーを使用してデータセットを一覧表示し、クエリを実行する例です：
 
 ```
-[Claude] Honeycombに「アプリケーションモニタリング」という名前の新しいデータセットを作成し、説明として「本番アプリケーションのモニタリング」を設定してください。
+[Claude] Honeycomb環境で利用可能なデータセットを表示していただけますか？
 
-[ユーザー] Honeycombに新しいデータセットを作成するのを手伝います。
+[ユーザー] はい、Honeycombにどのようなデータセットがあるか確認したいです。
 
-[Claude] Honeycombに新しいデータセットを作成します。
+[Claude] Honeycomb環境で利用可能なすべてのデータセットを一覧表示します。
 
-「アプリケーションモニタリング」という名前で、説明「本番アプリケーションのモニタリング」のデータセットを作成しています...
+honeycomb_datasets_listツールを使用します...
 
-[Claude は honeycomb_datasets_create を使用]
+利用可能なデータセットは以下の通りです：
+- production-metrics（スラグ: prod-metrics）
+- staging-services（スラグ: staging-svc）
+- application-logs（スラグ: app-logs）
 
-データセットが正常に作成されました！これでイベントを追加できます。
+どのデータセットについてさらに詳しく調べますか？
 
-テスト用に、このデータセットにサンプルイベントを作成しますか？
+[ユーザー] production-metricsデータセットを見てみましょう。
+
+[Claude] スラグ「prod-metrics」を使用してhoneycomb_dataset_getでproduction-metricsデータセットの詳細を取得します...
+
+次に、過去24時間の平均応答時間を示すクエリを作成して実行します。
+
+honeycomb_query_createとhoneycomb_query_result_createを使用します...
+
+平均応答時間の傾向を示す結果は次のとおりです：
+[クエリ結果の視覚化の説明]
 
 [ユーザー] はい、サンプルイベントを追加してください。
 

--- a/README.md
+++ b/README.md
@@ -68,137 +68,110 @@ This MCP server provides the following tools:
 ### Authentication
 
 1. `honeycomb_auth`
-   - Authenticates with the Honeycomb API
-   - Input:
-     - `apiKey` (string, optional): Honeycomb API key (if not provided, uses environment variable)
+   - Authenticates with the Honeycomb API and validates your API key
+   - No input parameters required (uses environment variable)
 
-#### Dataset Management
+### Dataset Management
 
 1. `honeycomb_datasets_list`
-   - Lists all available datasets
+   - Lists all available datasets in your Honeycomb environment
    - No input parameters required
 
 2. `honeycomb_dataset_get`
-   - Gets information about a specific dataset
+   - Gets detailed information about a specific dataset
    - Input:
-     - `datasetSlug` (string, required): Slug of the dataset
+     - `datasetSlug` (string, required): Slug of the dataset to retrieve
 
-3. `honeycomb_datasets_create`
-   - Creates a new dataset
-   - Input:
-     - `name` (string, required): Name of the dataset
-     - `description` (string, optional): Description of the dataset
-
-
-
-#### Column Management
+### Column Management
 
 1. `honeycomb_columns_list`
-   - Lists all columns in a dataset
+   - Lists all columns in a dataset with optional filtering
    - Input:
      - `datasetSlug` (string, required): Slug of the dataset
+     - `key_name` (string, optional): Filter by a specific column key name
 
-#### Query Management
+### Query Management
 
 1. `honeycomb_query_create`
    - Creates a new query for a dataset
    - Input:
      - `datasetSlug` (string, required): Slug of the dataset
-     - `query` (object, required): Query configuration
+     - `query` (object, required): Query configuration object with calculation, time range, and filters
 
-2. `honeycomb_query_result_create`
-   - Executes a query and returns the results
+2. `honeycomb_query_get`
+   - Gets information about a specific query
    - Input:
      - `datasetSlug` (string, required): Slug of the dataset
-     - `query` (object, required): Query configuration
+     - `queryId` (string, required): ID of the query to retrieve
 
-#### Event Management
-
-1. `honeycomb_event_create`
-   - Creates a new event in a dataset
+3. `honeycomb_query_result_create`
+   - Executes a query and returns the results (runs a query)
    - Input:
      - `datasetSlug` (string, required): Slug of the dataset
-     - `data` (object, required): Event data
+     - `queryId` (string, required): ID of the query to run
+     - `disable_series` (boolean, optional): Whether to disable series data
+     - `disable_total_by_aggregate` (boolean, optional): Whether to disable total aggregates
+     - `disable_other_by_aggregate` (boolean, optional): Whether to disable other aggregates
+     - `limit` (integer, optional): Limit on the number of results
 
+4. `honeycomb_query_result_get`
+   - Gets the results of a previously executed query
+   - Input:
+     - `datasetSlug` (string, required): Slug of the dataset
+     - `queryResultId` (string, required): ID of the query result to retrieve
 
+### Dataset Definitions
 
+1. `honeycomb_dataset_definitions_list`
+   - Lists dataset definitions with pagination support
+   - Input:
+     - `page` (number, optional): Page number (starting from 1)
+     - `limit` (number, optional): Number of results per page (default: 100, max: 1000)
+     - `sort_by` (string, optional): Field to sort by (e.g. 'name', 'description')
+     - `sort_order` (string, optional): Sort order ('asc' or 'desc')
 
-#### Board Management
+### Board Management
 
 1. `honeycomb_boards_list`
-   - Lists all boards
+   - Lists all available boards
    - No input parameters required
 
 2. `honeycomb_board_get`
-   - Gets information about a specific board
+   - Gets detailed information about a specific board
    - Input:
-     - `boardId` (string, required): ID of the board
-
-3. `honeycomb_board_create`
-   - Creates a new board
-   - Input:
-     - `name` (string, required): Name of the board
-     - `description` (string, optional): Description of the board
-     - `query_ids` (array of strings, optional): Query IDs to include in the board
-
-4. `honeycomb_board_update`
-   - Updates an existing board
-   - Input:
-     - `boardId` (string, required): ID of the board to update
-     - `name` (string, optional): New name for the board
-     - `description` (string, optional): New description for the board
-     - `query_ids` (array of strings, optional): New query IDs to include in the board
-
-
-
-#### Marker Management
-
-1. `honeycomb_markers_list`
-   - Lists all markers for a dataset
-   - Input:
-     - `datasetSlug` (string, required): Slug of the dataset
-
-2. `honeycomb_marker_create`
-   - Creates a new marker
-   - Input:
-     - `datasetSlug` (string, required): Slug of the dataset
-     - `message` (string, required): Message for the marker
-     - `type` (string, required): Type of the marker
-     - `start_time` (string, required): Start time for the marker
-     - `end_time` (string, optional): End time for the marker
-     - `url` (string, optional): URL associated with the marker
-   - Input:
-     - `datasetSlug` (string, required): Slug of the dataset
-     - `markerId` (string, required): ID of the marker to delete
-
-
-
+     - `boardId` (string, required): ID of the board to retrieve
 
 
 ## Example Usage
 
-Here's an example of Claude using this MCP server to create a new Honeycomb dataset and add an event:
+Here's an example of Claude using this MCP server to list datasets and run a query:
 
 ```
-[Claude] Please create a new dataset in Honeycomb called "Application Monitoring" with a description "Monitoring for our production application".
+[Claude] Can you show me the available datasets in our Honeycomb environment?
 
-[User] I'll help you create a new dataset in Honeycomb.
+[User] Sure, I'd like to see what datasets we have in Honeycomb.
 
-[Claude] I'll create a new dataset for you in Honeycomb. 
+[Claude] I'll list all the available datasets in your Honeycomb environment.
 
-I'll use the honeycomb_datasets_create tool:
+I'll use the honeycomb_datasets_list tool...
 
-Input:
-{
-  "name": "Application Monitoring",
-  "description": "Monitoring for our production application"
-}
+Here are your available datasets:
+- production-metrics (slug: prod-metrics)
+- staging-services (slug: staging-svc)
+- application-logs (slug: app-logs)
 
-The dataset has been created successfully!
+Which dataset would you like to explore further?
 
-[Claude] Now, let me add an event to this dataset. I'll create an event with some sample metrics.
+[User] Let's look at the production-metrics dataset.
 
-I'll use the honeycomb_event_create tool:
+[Claude] I'll get details about the production-metrics dataset using honeycomb_dataset_get with the slug "prod-metrics"...
+
+Now I'll create and run a query to show the average response time over the last 24 hours.
+
+I'll use honeycomb_query_create and then honeycomb_query_result_create...
+
+Here are the results showing the average response time trend:
+[Query results visualization description]
 
 Input:
 {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajirita2002/honeycomb-mcp-server",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "MCP server for interacting with honeycomb API",
   "license": "MIT",
   "author": "kajirita2002",


### PR DESCRIPTION
## Changes made
- Update README.md to reflect only currently implemented tools
- Update README.ja.md with the same changes in Japanese
- Fix column listing functionality in index.ts with key_name parameter
- Bump package version from 1.0.4 to 1.0.5 for npm publishing

## Reason for changes
To provide accurate documentation that matches the current implementation of the Honeycomb MCP server. The previous README included tools that were removed from the codebase.

## Key specifications
- All available tools are now correctly documented
- Example usage scenarios have been updated to reflect current functionality
- Documentation is consistent across both English and Japanese versions

## Impact scope
- Documentation only changes, no functional impact on runtime
- Users will see accurate tool descriptions aligned with actual functionality

## Testing details
- Manually verified all documented tools against the actual implementation in index.ts
- Confirmed formatting and content accuracy in both README versions